### PR TITLE
Add CZ Support to API

### DIFF
--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -159,7 +159,6 @@ class zenConnector():
                     data=json.dumps(apiBody),
                 )
             else:
-
                 r = self.requestSession.post(self._url,
                     auth=(self.config['username'], self.config['password']),
                     verify=self.config['ssl_verify'],


### PR DESCRIPTION
This adds CZ support to the API.

Two new configuration variables for creds.cfg:
cz=czname
apikey=hunter2