### PR TITLE
Feature/dict config input

### DIFF
--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -51,7 +51,7 @@ class zenConnector():
             '''
             configuration = self._sanitizeConfig(cfgFilePath)
             return configuration
-
+        # Use configuration file
         self.log.info('_getConfigDetails; section:%s, cfgFilePath:%s' % (section, cfgFilePath))
         configurations = ConfigParser.ConfigParser()
         if cfgFilePath == "":
@@ -63,7 +63,6 @@ class zenConnector():
             raise Exception('Specified configuration section, "%s" not defined in "%s".' % (section, cfgFilePath)) 
         configuration = {item[0]: item[1] for item in configurations.items(section)}
         configuration = self._sanitizeConfig(configuration)
-        import pdb; pdb.set_trace()
         return configuration
 
 

--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -44,6 +44,14 @@ class zenConnector():
         same directory as the python library file & return parameters in
         specific 'section'.
         '''
+        if isinstance(cfgFilePath, dict):
+            '''
+            Accept a dict of string values containing the input
+            instead of a configuration file path.
+            '''
+            configuration = self._sanitizeConfig(cfgFilePath)
+            return configuration
+
         self.log.info('_getConfigDetails; section:%s, cfgFilePath:%s' % (section, cfgFilePath))
         configurations = ConfigParser.ConfigParser()
         if cfgFilePath == "":
@@ -55,6 +63,7 @@ class zenConnector():
             raise Exception('Specified configuration section, "%s" not defined in "%s".' % (section, cfgFilePath)) 
         configuration = {item[0]: item[1] for item in configurations.items(section)}
         configuration = self._sanitizeConfig(configuration)
+        import pdb; pdb.set_trace()
         return configuration
 
 


### PR DESCRIPTION
Add an option to pass in a dict instead of using a configuration file.

```
import zenApiLib
cfg = {'username': 'admin', 'retries': '4.0', 'url': 'https://zenoss.foobar:443', 'disable_saml': 'False', 'timeout': '5.0', 'ssl_verify': 'False', 'password': 'zenoss'}
zenApi = zenApiLib.zenConnector(cfgFilePath = cfg)
```