### PR TITLE
Python3 Compatibility Changes

### DIFF
--- a/ZenAPIConnector.py
+++ b/ZenAPIConnector.py
@@ -83,7 +83,7 @@ class ZenAPIConnector_v1():
         if response.status_code == 200:
             return response
         else:
-            print 'HTTP Status: %s' % (response.status_code)
+            print('HTTP Status: %s' % (response.status_code))
 
 
 class ZenDeviceUuidFinder():

--- a/examples/APIGetDocumentation.py
+++ b/examples/APIGetDocumentation.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/APIGetDocumentation.py
+++ b/examples/APIGetDocumentation.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
                 api.setRouter(apiRouterName)
             except Exception as e:
                 if not args['silent']:
-                    print e
+                    print(e)
                 continue
             if amName == "*":
                 mName = api._routersInfo[apiRouterName]['methods'].keys()
@@ -65,14 +65,14 @@ if __name__ == '__main__':
             for apiMethodName in mName:
                 if apiMethodName not in api._routersInfo[apiRouterName]['methods'].keys():
                     if not args['silent']:
-                        print "Specified router method '%s' is not an option. Available methods for '%s' router are: %s" % (
+                        print("Specified router method '%s' is not an option. Available methods for '%s' router are: %s" % (
                             apiMethodName,
                             apiRouterName,
                             sorted(api._routersInfo[apiRouterName]['methods'].keys())
-                        )
+                        ))
                     continue
                 mInfo = api._routersInfo[apiRouterName]['methods'][apiMethodName]
-                print >>rOut, (
+                print((
                     "ROUTER NAME: {}\n"
                     "METHOD NAME: {}\n"
                     "METHOD DOCUMENTATION: {}\n"
@@ -85,6 +85,6 @@ if __name__ == '__main__':
                         mInfo['args'],
                         mInfo['kwargs']
                     )
-                )
+                ), file=rOut)
         if len(rName) > 1:
-            print '======================================'
+            print('======================================')

--- a/examples/Analytics_dumpAliases.py
+++ b/examples/Analytics_dumpAliases.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/Analytics_dumpAliases.py
+++ b/examples/Analytics_dumpAliases.py
@@ -64,7 +64,7 @@ def __printAliasLine(outputFile, path, dsName, dpName, alias, oid):
         writeStr = '%s # oid: %s' % ('|'.join(tokens), oid)
     else:
         writeStr = '%s' % ('|'.join(tokens))
-    print >>outputFile, writeStr
+    print(writeStr, file=outputFile)
 
 
 if __name__ == '__main__':
@@ -89,9 +89,9 @@ if __name__ == '__main__':
                                   id='/zport/dmd/Devices')
     seenTpls = []
     ALIASES = args['aliases']
-    print 'Writing all datapoints %s aliases to %s' % (ALIASES,
-                                                       args['outFileName'])
-    print >>ALIAS_FILE, '#template binding path|template|datasource|datapoint|alias|rpn'
+    print('Writing all datapoints %s aliases to %s' % (ALIASES,
+                                                       args['outFileName']))
+    print('#template binding path|template|datasource|datapoint|alias|rpn', file=ALIAS_FILE)
     for templ in getAllTemplates():
         path = templ['uid']
         # Skip template if we're already done it
@@ -123,5 +123,5 @@ if __name__ == '__main__':
             elif not dp['aliases']:
                 __printAliasLine(ALIAS_FILE, path, dsName, dpName, None, oid)
                     
-    print 'Finished. All datapoints %s aliases exported to %s' % (ALIASES,
-                                                                  args['outFileName'])
+    print('Finished. All datapoints %s aliases exported to %s' % (ALIASES,
+                                                                  args['outFileName']))

--- a/examples/Analytics_manageAliases.py
+++ b/examples/Analytics_manageAliases.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/Analytics_manageAliases.py
+++ b/examples/Analytics_manageAliases.py
@@ -82,9 +82,9 @@ if __name__ == '__main__':
         api.config['timeout'] = 30
 
     if args['commit']:
-        print "Commit turned on, changes will be commited via the API"
+        print("Commit turned on, changes will be commited via the API")
     else:
-        print "Dry run only - no changes will be commited. Reun with --commit after reviewing output."
+        print("Dry run only - no changes will be commited. Reun with --commit after reviewing output.")
 
     # now that we've validated args, open the aliases file and loop through it looking for specified aliases in dmd
     with open(args['inFileName']) as fp:
@@ -99,7 +99,7 @@ if __name__ == '__main__':
                 path, tplId, dsId, dpId, aliasId, rpnFormula = lineChunk.split('|')
             except ValueError:
                 # Malformed line
-                print ' X',line
+                print(' X',line)
                 continue
 
             # Do not need to get Template or DataSource Details...
@@ -134,10 +134,10 @@ if __name__ == '__main__':
                     formula = '' if formula is None else formula
                     if formula == rpnFormula:
                         # We found the alias, and the RPN matches, so log a match, nothing to do
-                        print '  ', line.rstrip()
+                        print('  ', line.rstrip())
                     else:
                         # We found the alias, but we need to update the RPN, so log an RPN update
-                        print 'R ', line.rstrip()
+                        print('R ', line.rstrip())
                         if args['commit']:
                             apiDPChg = api.callMethod('setInfo',
                                                uid = dsUid,
@@ -147,14 +147,14 @@ if __name__ == '__main__':
                                                          }]
                                                )
                             if not apiDPChg['result']['success']:
-                                print >>sys.stderr, "Formula change for alias '{}' was not successful. {}".format(
+                                print("Formula change for alias '{}' was not successful. {}".format(
                                     dsUid,
                                     pformat(apiDPChg)
-                                )
+                                ), file=sys.stderr)
                             sys.exit()
                 else:
                     # We didn't find the alias, so add it and the RPN, if any, and log an add
-                    print '+ ', line.rstrip()
+                    print('+ ', line.rstrip())
                     if args['commit']:
                         apiDPChg = api.callMethod('setInfo',
                                            uid = dsUid,
@@ -164,10 +164,10 @@ if __name__ == '__main__':
                                                      }]
                                            )
                         if not apiDPChg['result']['success']:
-                            print >>sys.stderr, "Formula change for alias '{}' was not successful. {}".format(
+                            print("Formula change for alias '{}' was not successful. {}".format(
                                 dsUid,
                                 pformat(apiDPChg)
-                            )
+                            ), file=sys.stderr)
             # If we're attempting to remove an alias...
             elif args['action'] == 'remove':
                 if alias:
@@ -177,20 +177,20 @@ if __name__ == '__main__':
                     formula = '' if formula is None else formula
                     if formula == rpnFormula:
                         # We found the RPN matches, so remove the alias and RPN and log a removal
-                        print '- ', line.rstrip()
+                        print('- ', line.rstrip())
                         #datapoint.removeAlias(aliasId)
                         if args['commit']:
                             apiDPChg = api.callMethod('setInfo',
                                                uid = dsUid,
                                                aliases = rmAlias)
                             if not apiDPChg['result']['success']:
-                                print >>sys.stderr, "Formula change for alias '{}' was not successful. {}".format(
+                                print("Formula change for alias '{}' was not successful. {}".format(
                                     dsUid,
                                     pformat(apiDPChg)
-                                )                        
+                                ), file=sys.stderr)                        
                     else:
                         # We RPN doesn't match so log the inability to remove the alias and RPN due to RPN mismatch
-                        print ' r', line.rstrip()
+                        print(' r', line.rstrip())
                 else:
                     # We couldn't find the alias, so log the inability to find the alias
-                    print ' a', line.rstrip()
+                    print(' a', line.rstrip())

--- a/examples/DashboardRouter_getDeviceIssues.py
+++ b/examples/DashboardRouter_getDeviceIssues.py
@@ -5,7 +5,7 @@
 # JSON API and the ZenAPIConnector class written by #
 # Adam McCurdy @ Zenoss                             #
 #####################################################
-
+from __future__ import print_function
 import zenApiLib
 
 

--- a/examples/DashboardRouter_getDeviceIssues.py
+++ b/examples/DashboardRouter_getDeviceIssues.py
@@ -15,8 +15,8 @@ def deviceIssuesReport():
     .csv format. There are several other fields one might be
     interested in here, but here are a few as an example.
     '''
-    print 'Device, Device Class, ProdState, Clear, Debug, Info '\
-          'Warning, Error, Critical'
+    print('Device, Device Class, ProdState, Clear, Debug, Info '\
+          'Warning, Error, Critical')
     dr = zenApiLib.zenConnector(routerName = 'DashboardRouter')
     report_data = dr.callMethod('getDeviceIssues')
     if report_data.get('result', {}).get('success', False) is False:
@@ -33,7 +33,7 @@ def deviceIssuesReport():
         warning = events['warning']['count']
         error = events['error']['count']
         critical = events['critical']['count']
-        print '%s, %s, %s, %s, %s, %s, %s, %s, %s' % (device,
+        print('%s, %s, %s, %s, %s, %s, %s, %s, %s' % (device,
                                                       deviceClass,
                                                       prodState,
                                                       clear,
@@ -41,7 +41,7 @@ def deviceIssuesReport():
                                                       info,
                                                       warning,
                                                       error,
-                                                      critical)
+                                                      critical))
 
 
 if __name__ == '__main__':

--- a/examples/DeviceDumpLoadRouter_exportDevices.py
+++ b/examples/DeviceDumpLoadRouter_exportDevices.py
@@ -1,12 +1,18 @@
-#!/bin/env python
+#!/usr/bin/env python
+
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys
 import logging
 import os
-from urlparse import urlparse
 from datetime import date
 from pprint import pformat
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 def buildArgs():
     parser = argparse.ArgumentParser(description='Poll & display API Router & '
@@ -76,6 +82,7 @@ if __name__ == '__main__':
                 ))
                 print(apiResult['result']['data'], file=rOut)
             else:
+                pass
                 print("ERROR: API results nonsuccessfull\n{}".format(
                     pformat(apiResult)
                 ), file=sys.stderr)
@@ -96,6 +103,7 @@ if __name__ == '__main__':
                 ))
                 print(apiResult['result']['data'], file=rOut)
             else:
+                pass
                 print("ERROR: API results nonsuccessfull\n{}".format(
                     pformat(apiResult)
                 ), file=sys.stderr)

--- a/examples/DeviceDumpLoadRouter_exportDevices.py
+++ b/examples/DeviceDumpLoadRouter_exportDevices.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         # ?Bug? (ZEN-31017) - work-around via multiple api calls
         # -- Get device classes first
         if args['exOrg']:
-            print >>rOut, "#### {} extract of classes ####".format(devClass)
+            print("#### {} extract of classes ####".format(devClass), file=rOut)
             apiResult = api.callMethod(
                 'exportDevices',
                 options={
@@ -74,13 +74,13 @@ if __name__ == '__main__':
                     devClass,
                     apiResult['result']['deviceCount']
                 ))
-                print >>rOut, apiResult['result']['data']
+                print(apiResult['result']['data'], file=rOut)
             else:
-                print >>sys.stderr, "ERROR: API results nonsuccessfull\n{}".format(
+                print("ERROR: API results nonsuccessfull\n{}".format(
                     pformat(apiResult)
-                )
+                ), file=sys.stderr)
         if args['exDev']:
-            print >>rOut, "#### {} extract of devices ####".format(devClass)
+            print("#### {} extract of devices ####".format(devClass), file=rOut)
             # -- now devices, with its deviceClass defined in the moveDevice batchload parameter
             apiResult = api.callMethod(
                 'exportDevices',
@@ -94,8 +94,8 @@ if __name__ == '__main__':
                     devClass,
                     apiResult['result']['deviceCount']
                 ))
-                print >>rOut, apiResult['result']['data']
+                print(apiResult['result']['data'], file=rOut)
             else:
-                print >>sys.stderr, "ERROR: API results nonsuccessfull\n{}".format(
+                print("ERROR: API results nonsuccessfull\n{}".format(
                     pformat(apiResult)
-                )
+                ), file=sys.stderr)

--- a/examples/DeviceDumpLoadRouter_importDevices.py
+++ b/examples/DeviceDumpLoadRouter_importDevices.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/DeviceDumpLoadRouter_importDevices.py
+++ b/examples/DeviceDumpLoadRouter_importDevices.py
@@ -50,9 +50,9 @@ if __name__ == '__main__':
                     data=fp.read())
     fp.close()
     if apiResult['result']['success']:
-        print >>sys.stderr, "Import successful, import stats: {}".format(
+        print("Import successful, import stats: {}".format(
             apiResult['result']['stats']
-        )
+        ), file=sys.stderr)
     else:
-        print >>sys.stderr, "ERROR: API results nonsuccessfull\n{}".format(
-            pformat(apiResult))
+        print("ERROR: API results nonsuccessfull\n{}".format(
+            pformat(apiResult)), file=sys.stderr)

--- a/examples/DeviceManagementRouter_DeleteMaintenanceWindows.py
+++ b/examples/DeviceManagementRouter_DeleteMaintenanceWindows.py
@@ -4,6 +4,7 @@
 # example of how to remove old maintenance windows from a      #
 # specific device                                              #
 ################################################################
+from __future__ import print_function
 import zenApiLib
 from time import time
 

--- a/examples/DeviceManagementRouter_DeleteMaintenanceWindows.py
+++ b/examples/DeviceManagementRouter_DeleteMaintenanceWindows.py
@@ -21,4 +21,4 @@ for mwindow in response['result']['data']:
         time_to_delete = curr_time - 86400
         if mwindow['start'] < time_to_delete:
             del_resp = delete_maint_window(mwindow['uid'], mwindow['id'])
-            print del_resp
+            print(del_resp)

--- a/examples/DeviceManagementRouter_addMaintWindow_SysArgv.py
+++ b/examples/DeviceManagementRouter_addMaintWindow_SysArgv.py
@@ -6,7 +6,7 @@ import sys
 usage = '%s <uid> <durationHours> <prodState> <name>' % (sys.argv[0])
 
 if len(sys.argv) != 5:
-    print usage
+    print(usage)
     sys.exit(1)
 else:
     uid = sys.argv[1]

--- a/examples/DeviceManagementRouter_addMaintWindow_SysArgv.py
+++ b/examples/DeviceManagementRouter_addMaintWindow_SysArgv.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import zenApiLib
 import time
 import sys

--- a/examples/DeviceModelAgeReport.py
+++ b/examples/DeviceModelAgeReport.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/DeviceModelAgeReport.py
+++ b/examples/DeviceModelAgeReport.py
@@ -55,13 +55,13 @@ if __name__ == '__main__':
             if not pagedResults['result']['success']:
                 raise Exception(pagedResults['msg'])
         except Exception as e:
-            print >> sys.stderr, "ERROR: {!r}".format(e)
-            print >> sys.stderr, pformat(pagedResults)
+            print("ERROR: {!r}".format(e), file=sys.stderr)
+            print(pformat(pagedResults), file=sys.stderr)
             sys.exit(1)
         for event in pagedResults['result']['events']:
             issues[event['device']['text']] = event['summary']
     # Loop through Devices and report on model dates
-    print >> rOut, "Device Class, Device ID, Device Title, Last Modeled DateTime, Last Modeled Date, Production State, Model Events, Status Up/Down"
+    print("Device Class, Device ID, Device Title, Last Modeled DateTime, Last Modeled Date, Production State, Model Events, Status Up/Down", file=rOut)
     api.setRouter('DeviceRouter')
     for pagedResults in api.pagingMethodCall('getDevices',
                                              keys=['uid', 'id', 'name', 'status', 'lastCollected', 'productionStateLabel'],
@@ -70,11 +70,11 @@ if __name__ == '__main__':
             if not pagedResults['result']['success']:
                 raise Exception(pagedResults['msg'])
         except Exception as e:
-            print >> sys.stderr, "ERROR: {!r}".format(e)
-            print >> sys.stderr, pformat(pagedResults)
+            print("ERROR: {!r}".format(e), file=sys.stderr)
+            print(pformat(pagedResults), file=sys.stderr)
             sys.exit(1)
         for device in pagedResults['result']['devices']:
-            print >> rOut, '{},{},{},{},{},{},"{}",{}'.format(
+            print('{},{},{},{},{},{},"{}",{}'.format(
                 '/'.join(device['uid'].split('/')[4:-2]),
                 device['id'],
                 (device['name'] if device['name'] != device['id'] else ''),
@@ -85,4 +85,4 @@ if __name__ == '__main__':
                 device['productionStateLabel'],
                 issues.get(device['name'], 'No Events'),
                 ('UP' if device['status'] else 'DOWN')
-            )
+            ), file=rOut)

--- a/examples/DeviceRouter_ResetIPandRemodel.py
+++ b/examples/DeviceRouter_ResetIPandRemodel.py
@@ -4,6 +4,7 @@
 # addresses and remodel devices based on a device   #
 # organizer using the JSON API and zenAPILib        #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/DeviceRouter_ResetIPandRemodel.py
+++ b/examples/DeviceRouter_ResetIPandRemodel.py
@@ -26,7 +26,7 @@ def resetIPAndRemodel():
      for dev in devlist:
          deviceRouter.callMethod('resetIp', uids=dev)
          deviceRouter.callMethod('remodel', deviceUid=dev)
-         print "Resetting IP and Remodeling %s" % dev
+         print("Resetting IP and Remodeling %s" % dev)
 
 if __name__ == '__main__':
     resetIPAndRemodel()

--- a/examples/DeviceRouter_addDevice.py
+++ b/examples/DeviceRouter_addDevice.py
@@ -16,7 +16,7 @@ usage = '%s <device_id> <device_class_name> <productionState>' % (sys.argv[0])
 
 
 def fail():
-    print 'Invalid arguments. \nUsage: %s' % (usage)
+    print('Invalid arguments. \nUsage: %s' % (usage))
     sys.exit(1)
 
 
@@ -57,4 +57,4 @@ if __name__ == '__main__':
     '''
     data = buildArgs()
     api_response = addDevice(data)
-    print api_response
+    print(api_response)

--- a/examples/DeviceRouter_addDevice.py
+++ b/examples/DeviceRouter_addDevice.py
@@ -5,6 +5,7 @@
 # Zenoss JSON API and the ZenAPIConnector class     #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import sys
 import zenApiLib

--- a/examples/DeviceRouter_addDeviceCheckJob.py
+++ b/examples/DeviceRouter_addDeviceCheckJob.py
@@ -19,7 +19,7 @@ usage = '%s <device_id> <device_class_name> <productionState>' % (sys.argv[0])
 
 
 def fail():
-    print 'Invalid arguments. \nUsage: %s' % (usage)
+    print('Invalid arguments. \nUsage: %s' % (usage))
     sys.exit(1)
 
 
@@ -60,6 +60,6 @@ if __name__ == '__main__':
     '''
     data = buildArgs()
     api_response = addDevice(data)
-    print 'Created job %s... watching job status' % (api_response)
+    print('Created job %s... watching job status' % (api_response))
     jobstatus = watchStatus(api_response, 300)
-    print 'Job status %s, Success: %s' % (jobstatus[0], jobstatus[1])
+    print('Job status %s, Success: %s' % (jobstatus[0], jobstatus[1]))

--- a/examples/DeviceRouter_addDeviceCheckJob.py
+++ b/examples/DeviceRouter_addDeviceCheckJob.py
@@ -5,6 +5,7 @@
 # Zenoss JSON API and the ZenAPIConnector class     #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import sys
 import zenApiLib

--- a/examples/DeviceRouter_addDeviceCheckJobGetUid.py
+++ b/examples/DeviceRouter_addDeviceCheckJobGetUid.py
@@ -6,6 +6,7 @@
 # Zenoss JSON API and the ZenAPIConnector class     #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import sys
 import zenApiLib

--- a/examples/DeviceRouter_addDeviceCheckJobGetUid.py
+++ b/examples/DeviceRouter_addDeviceCheckJobGetUid.py
@@ -20,7 +20,7 @@ usage = '%s <device_id> <device_class_name> <productionState>' % (sys.argv[0])
 
 
 def fail():
-    print 'Invalid arguments. \nUsage: %s' % (usage)
+    print('Invalid arguments. \nUsage: %s' % (usage))
     sys.exit(1)
 
 
@@ -61,8 +61,8 @@ if __name__ == '__main__':
     '''
     data = buildArgs()
     api_response = addDevice(data)
-    print 'Created job %s... watching job status' % (api_response)
+    print('Created job %s... watching job status' % (api_response))
     jobstatus = watchStatus(api_response, 300)
-    print 'Job status %s, Success: %s' % (jobstatus[0], jobstatus[1])
+    print('Job status %s, Success: %s' % (jobstatus[0], jobstatus[1]))
     devfind = ZenDeviceUidFinder(sys.argv[1])
-    print 'Device UID is %s' % (devfind.first())
+    print('Device UID is %s' % (devfind.first()))

--- a/examples/DeviceRouter_checkInMaintTooLong.py
+++ b/examples/DeviceRouter_checkInMaintTooLong.py
@@ -1,4 +1,5 @@
 #!/bin/python
+from __future__ import print_function
 import argparse
 import os
 import json

--- a/examples/DeviceRouter_getDevices.py
+++ b/examples/DeviceRouter_getDevices.py
@@ -5,6 +5,7 @@
 # using the Zenoss JSON API and the ZenAPIConnector #
 # class written by Adam McCurdy @ Zenoss            #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/DeviceRouter_getDevices.py
+++ b/examples/DeviceRouter_getDevices.py
@@ -19,7 +19,7 @@ def deviceReport():
     .csv format. There are numerous other fields that can
     be displayed here, but here are a few as an example.
     '''
-    print 'Name, IP Address, UID, ProdState, Collector, Location'
+    print('Name, IP Address, UID, ProdState, Collector, Location')
     dr = zenApiLib.zenConnector(routerName = router)
     for device_resp in dr.pagingMethodCall(method, **data):
         if device_resp.get('result', {}).get('success', False) is False:
@@ -29,12 +29,12 @@ def deviceReport():
                 location = dev['location']['uid']
             except (KeyError, TypeError):
                 location = ''
-            print '%s, %s, %s, %s, %s, %s' % (dev['name'],
+            print('%s, %s, %s, %s, %s, %s' % (dev['name'],
                                               dev['ipAddressString'],
                                               dev['uid'],
                                               dev['productionState'],
                                               dev['collector'],
-                                              location)
+                                              location))
 
 
 if __name__ == '__main__':

--- a/examples/DeviceRouter_getOSProcesses.py
+++ b/examples/DeviceRouter_getOSProcesses.py
@@ -20,4 +20,4 @@ for device_uid in device_uids:
     # if the totalCount is greater than zero, let's print out the device name, component name, and the monitored state
     if getcomp_result['totalCount'] > 0:
         for component in getcomp_result['data']:
-            print '%s, %s, %s' % (device_uid, component['name'], component['monitored'])
+            print('%s, %s, %s' % (device_uid, component['name'], component['monitored']))

--- a/examples/DeviceRouter_getOSProcesses.py
+++ b/examples/DeviceRouter_getOSProcesses.py
@@ -4,6 +4,7 @@
 # been modeled on or added to servers, along with their 
 # monitored state             
 #######################################################
+from __future__ import print_function
 import zenApiLib
 zenApi = zenApiLib.zenConnector()
 zenApi.setRouter('DeviceRouter')

--- a/examples/DeviceRouter_moveDevice.py
+++ b/examples/DeviceRouter_moveDevice.py
@@ -5,7 +5,7 @@
 # Zenoss JSON API and the ZenAPIConnector class     #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
-#
+from __future__ import print_function
 
 import sys
 import zenApiLib

--- a/examples/DeviceRouter_moveDevice.py
+++ b/examples/DeviceRouter_moveDevice.py
@@ -18,7 +18,7 @@ usage = '%s <device_id> <device_class_name>' % (sys.argv[0])
 
 
 def fail():
-    print 'Invalid arguments. \nUsage: %s' % (usage)
+    print('Invalid arguments. \nUsage: %s' % (usage))
     sys.exit(1)
 
 
@@ -61,5 +61,5 @@ if __name__ == '__main__':
         raise Exception('Multiple devices found that matched "%s"' % data['deviceName'])
     data['uid'] = deviceFindResults.getFirstUid()
     api_response = moveDevice(uids=data['uid'], target=data['deviceClass'])
-    print data
-    print api_response
+    print(data)
+    print(api_response)

--- a/examples/DeviceRouter_remodel.py
+++ b/examples/DeviceRouter_remodel.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 from zenApiDeviceRouterHelper import ZenDeviceUidFinder
 from zenApiJobsRouterHelper import watchStatus

--- a/examples/DeviceRouter_remodel.py
+++ b/examples/DeviceRouter_remodel.py
@@ -59,23 +59,23 @@ if __name__ == '__main__':
         try:
             validModelerPlugins = sorted(apiResult['result']['data'].keys())
         except Exception as e:
-            print >> sys.stderr, "ERROR getting modelerPlugins!"
-            print >> sys.stderr, pformat(apiResult)
-            print >> sys.stderr, e
+            print("ERROR getting modelerPlugins!", file=sys.stderr)
+            print(pformat(apiResult), file=sys.stderr)
+            print(e, file=sys.stderr)
             sys.exit(1)
         for mPlugin in args['modelerPlugins'].split("|"):
             if mPlugin not in validModelerPlugins:
-                print >> sys.stderr, "ERROR: Specified modelerPlugin '{}' is not an option. " \
+                print("ERROR: Specified modelerPlugin '{}' is not an option. " \
                       "Available plugins are: {}".format(
                         mPlugin,
                         validModelerPlugins
-                      )
+                      ), file=sys.stderr)
                 sys.exit(2)
     # Loop over specified devices
     for devName in args['deviceNames']:
         results = ZenDeviceUidFinder(name=devName)
         if results.getCount() != 1:
-            print >> sys.stderr, 'Skipping "{}", found {} devices.'.format(devName, results.getCount())
+            print('Skipping "{}", found {} devices.'.format(devName, results.getCount()), file=sys.stderr)
             continue
         devUid = results.getFirstUid()
         apiResult = api.callMethod(
@@ -85,19 +85,19 @@ if __name__ == '__main__':
             background=True
         )
         if not apiResult['result']['success']:
-            print 'Remodeling API cal failed'
+            print('Remodeling API cal failed')
             pprint(apiResult)
             continue
         else:
-            print >> rOut, "{} - {}".format(devName, apiResult['result']['jobId'])
+            print("{} - {}".format(devName, apiResult['result']['jobId']), file=rOut)
             jobIds.append([devName, apiResult['result']['jobId']])
     # Hold off exiting the script
     if args['wait']:
-        print >> rOut, "Waiting on remodel jobs to complete..."
+        print("Waiting on remodel jobs to complete...", file=rOut)
         for job in jobIds:
             devName, jobId = job
             jobSuccess = watchStatus(jobId)
             if not jobSuccess:
-                print >> rOut, "{} remodel job unsuccessful".format(devName)
+                print("{} remodel job unsuccessful".format(devName), file=rOut)
                 break
-            print >> rOut, "{} remodel job completed".format(devName)
+            print("{} remodel job completed".format(devName), file=rOut)

--- a/examples/DeviceRouter_removeDevice.py
+++ b/examples/DeviceRouter_removeDevice.py
@@ -4,6 +4,7 @@
 # device into Zenoss Resource Manager using the     #
 # Zenoss JSON API and the Zenoss RM API Library    #
 #####################################################
+from __future__ import print_function
 
 
 import sys

--- a/examples/DeviceRouter_removeDevice.py
+++ b/examples/DeviceRouter_removeDevice.py
@@ -20,7 +20,7 @@ response = ZenDeviceUidFinder(name=device_id)
 if response.getCount() == 1:
     device_uid = response.getFirstUid()
 else:
-    print 'Found %s devices.' % (response.getCount())
+    print('Found %s devices.' % (response.getCount()))
     sys.exit(1)
 
 dr = zenApiLib.zenConnector(routerName = 'DeviceRouter')
@@ -28,4 +28,4 @@ dr = zenApiLib.zenConnector(routerName = 'DeviceRouter')
 delete_response = dr.callMethod('removeDevices', uids=device_uid, hashcheck="", action="delete")
 
 if delete_response['result']['success'] == True:
-    print 'Successfully deleted device: %s' % (device_uid)
+    print('Successfully deleted device: %s' % (device_uid))

--- a/examples/DeviceRouter_renameDevice.py
+++ b/examples/DeviceRouter_renameDevice.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     newDeviceName = args['newDeviceName']
     results = ZenDeviceUidFinder(name=deviceName)
     if results.getCount() != 1:
-       print >> sys.stderr, 'Skipping "{}", found {} devices.'.format(deviceName, results.getCount())
+       print('Skipping "{}", found {} devices.'.format(deviceName, results.getCount()), file=sys.stderr)
        sys.exit()
         
     devUid = results.getFirstUid()
@@ -69,7 +69,7 @@ if __name__ == '__main__':
             retainGraphData=retainData
         )
     if not apiResult['result']['success']:
-       print >> sys.stderr, 'Renaming API call failed'
+       print('Renaming API call failed', file=sys.stderr)
        pprint(apiResult)
     else:
-       print >> rOut, "Renaming {} to {} initiated - Keeping data {}".format(deviceName, newDeviceName, retainData)
+       print("Renaming {} to {} initiated - Keeping data {}".format(deviceName, newDeviceName, retainData), file=rOut)

--- a/examples/DeviceRouter_renameDevice.py
+++ b/examples/DeviceRouter_renameDevice.py
@@ -1,5 +1,6 @@
-# Re id a device 
 #!/bin/env python
+# Re id a device
+from __future__ import print_function
 import zenApiLib
 from zenApiDeviceRouterHelper import ZenDeviceUidFinder
 from zenApiJobsRouterHelper import watchStatus

--- a/examples/EventClassesRouter_disabledTransforms.py
+++ b/examples/EventClassesRouter_disabledTransforms.py
@@ -10,7 +10,7 @@ def transformEnabled(evtUid):
     '''
     rsp = api.callMethod('isTransformEnabled', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', 'Unknown')
@@ -21,7 +21,7 @@ def getMappings(evtUid):
     '''
     rsp = api.callMethod('getInstances', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', [])
@@ -36,7 +36,7 @@ def mappings(evtClsUid='/zport/dmd/Events'):
         if mapping.get('hasTransform', False):
             if not transformEnabled(mapping['uid']):
                 mappingPath = mapping.get('uid', 'Unknown').replace('/zport/dmd/', '').replace('/instances/', '/')
-                print 'Mapping {} transform DISABLED'.format(mappingPath)
+                print('Mapping {} transform DISABLED'.format(mappingPath))
 
 def check4transform(evtCls):
     '''
@@ -44,7 +44,7 @@ def check4transform(evtCls):
     '''
     if evtCls.get("text", {}).get("hasTransform", False):
         if not transformEnabled(evtCls['uid']):
-            print 'EventClass {} transform DISABLED'.format(evtCls['path'])
+            print('EventClass {} transform DISABLED'.format(evtCls['path']))
 
 def eventClasses(evtClsUid):
     '''

--- a/examples/EventClassesRouter_disabledTransforms.py
+++ b/examples/EventClassesRouter_disabledTransforms.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 
 import zenApiLib
 import sys

--- a/examples/EventClassesRouter_exportTransforms.py
+++ b/examples/EventClassesRouter_exportTransforms.py
@@ -12,7 +12,7 @@ def getTransform(evtUid):
     '''
     rsp = api.callMethod('getTransform', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', 'Unknown')
@@ -23,7 +23,7 @@ def getMappings(evtUid):
     '''
     rsp = api.callMethod('getInstances', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', [])
@@ -72,15 +72,15 @@ def write2File(sType, sUid, sData):
         sUid,
         sType
     )
-    print "INFO: writing {}".format(
+    print("INFO: writing {}".format(
         sFilePath
-    )
+    ))
     try:
         oFile = open(sFilePath, 'w')
         oFile.write(sData)
         oFile.close()
     except Exception, e:
-        print "ERROR: %s" % (e)
+        print("ERROR: %s" % (e))
         sys.exit(1)
 
 

--- a/examples/EventClassesRouter_exportTransforms.py
+++ b/examples/EventClassesRouter_exportTransforms.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import sys
 import os

--- a/examples/EventClassesRouter_listTransforms.py
+++ b/examples/EventClassesRouter_listTransforms.py
@@ -14,7 +14,7 @@ def getTransform(evtUid):
     '''
     rsp = api.callMethod('getTransform', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', 'Unknown')
@@ -25,7 +25,7 @@ def getMappings(evtUid):
     '''
     rsp = api.callMethod('getInstances', uid=evtUid)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return  rsp.get('result', {}).get('data', [])
@@ -40,8 +40,8 @@ def mappings(evtClsUid='/zport/dmd/Events'):
         if mapping.get('hasTransform', False):
             mappingPath = mapping.get('uid', 'Unknown').replace('/zport/dmd/', '').replace('/instances/', '/')
             label = '[Mapping] %s' % mappingPath
-            print '%s\n%s' % (label, '-' * len(label))
-            print getTransform(mapping['uid']), "\n"
+            print('%s\n%s' % (label, '-' * len(label)))
+            print(getTransform(mapping['uid']), "\n")
 
 def check4transform(evtCls):
     '''
@@ -49,8 +49,8 @@ def check4transform(evtCls):
     '''
     if evtCls.get("text", {}).get("hasTransform", False):
         label = '[Transform] %s' % evtCls['path']
-        print '%s\n%s' % (label, '-' * len(label))
-        print getTransform(evtCls['uid']), "\n"
+        print('%s\n%s' % (label, '-' * len(label)))
+        print(getTransform(evtCls['uid']), "\n")
 
 def eventClasses(evtClsUid):
     '''

--- a/examples/EventClassesRouter_listTransforms.py
+++ b/examples/EventClassesRouter_listTransforms.py
@@ -1,7 +1,7 @@
 #!/bin/env python
-
 # API version of script found at:
 # https://support.zenoss.com/hc/en-us/articles/202423289-How-To-List-All-Event-Transforms-and-Event-Class-Mappings
+from __future__ import print_function
 
 
 import zenApiLib

--- a/examples/EventsRouter_clearHeartbeats.py
+++ b/examples/EventsRouter_clearHeartbeats.py
@@ -1,5 +1,6 @@
 #!/bin/env python
 # Clear Heartbeats
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/EventsRouter_heartbeats.py
+++ b/examples/EventsRouter_heartbeats.py
@@ -25,7 +25,7 @@ def heartbeats(api):
            }
     rsp = api.callMethod('query', **data)
     if rsp.get('result', {}).get('success', False) == False:
-        print "ERROR"
+        print("ERROR")
         pprint(rsp)
         sys.exit(1)
     return rsp.get('result', {}).get('events', 'Unknown')

--- a/examples/EventsRouter_heartbeats.py
+++ b/examples/EventsRouter_heartbeats.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 
 import zenApiLib
 import sys

--- a/examples/EventsRouter_queryEvents.py
+++ b/examples/EventsRouter_queryEvents.py
@@ -278,5 +278,5 @@ if __name__ == '__main__':
     results = makeQuery(data, count)
 
     for result in results:
-        print(json.dumps(extractEvents(result)))
+        print((json.dumps(extractEvents(result))))
 

--- a/examples/EventsRouter_queryEvents.py
+++ b/examples/EventsRouter_queryEvents.py
@@ -5,6 +5,7 @@
 # Zenoss JSON API and the ZenAPIConnector class     #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 import sys

--- a/examples/ImpactRouter_copyPolicies.py
+++ b/examples/ImpactRouter_copyPolicies.py
@@ -7,6 +7,7 @@
 #
 # To run type:
 #     python impact_api_copy_paste_policy_gates.py
+from __future__ import print_function
 
 
 from zenApiImpactRouterHelper import (

--- a/examples/ImpactRouter_copyPolicies.py
+++ b/examples/ImpactRouter_copyPolicies.py
@@ -68,7 +68,7 @@ def setPolicies(copyPolicyData, serviceOrganizer, serviceName, contextUid, polic
     #       u'properties': {u'threshold': u'100'}}
 
     for policy in copyPolicyData:
-        print '\nSetting policy: %s' % policy
+        print('\nSetting policy: %s' % policy)
         api.set_policy(
             serviceUid=IMPACT_ROOT+serviceOrganizer+'/services'+serviceName,
             contextUid=contextUid, 
@@ -103,7 +103,7 @@ def copyPoliciesToServices():
         copyPolicies=getPolicies(copyFromOrganizer, copyFromService, contextUid, policyType)
     
         # Print the current policies for the current source and target services
-        print '\nCopied Policies from %s%s:' % (copyFromOrganizer, copyFromService)
+        print('\nCopied Policies from %s%s:' % (copyFromOrganizer, copyFromService))
         pprint(copyPolicies)
 
         #print '\nCurrent Policies on %s%s:' % (copyToOrganizer, copyToService)
@@ -113,7 +113,7 @@ def copyPoliciesToServices():
         setPolicies(copyPolicies['data'], copyToOrganizer, toService, contextUid, policyType)
 
         # print the target service's new policies for audit purposes
-        print '\nNew Policies on %s%s:' % (copyToOrganizer, toService)
+        print('\nNew Policies on %s%s:' % (copyToOrganizer, toService))
         pprint(getPolicies(copyToOrganizer, toService, contextUid, policyType))
 
 if __name__ == '__main__':

--- a/examples/ImpactRouter_createService.py
+++ b/examples/ImpactRouter_createService.py
@@ -8,23 +8,23 @@ from zenApiImpactRouterHelper import (
 api = zenApiImpactRouterHelper()
 
 def createExampleService():
-    print "Creating organizer: extra_example_org"
+    print("Creating organizer: extra_example_org")
     org = api.create_organizer(IMPACT_ROOT, 'extra_example_org')
     if not org['success']:
         raise Exception("Unable to create organizer extra_example_org")
 
-    print "Creating services"
+    print("Creating services")
     orgUid = org['data']['uid']
     api.create_service(orgUid, 'extra_examples')
     api.create_service(orgUid, 'extra_example_1')
     api.create_service(orgUid, 'extra_example_2')
 
-    print "Adding impacts"
+    print("Adding impacts")
     orgPath = orgUid + '/services/'
     api.add_impact(orgPath + 'extra_examples', orgPath + 'extra_example_1')
     api.add_impact(orgPath + 'extra_examples', orgPath + 'extra_example_2')
 
-    print "Finished creating sample graph in organizer 'extra_examples'.\n"
+    print("Finished creating sample graph in organizer 'extra_examples'.\n")
 
 if __name__ == '__main__':
     createExampleService()

--- a/examples/ImpactRouter_createService.py
+++ b/examples/ImpactRouter_createService.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from zenApiImpactRouterHelper import (
     zenApiImpactRouterHelper,

--- a/examples/ImpactRouter_printTree.py
+++ b/examples/ImpactRouter_printTree.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from zenApiImpactRouterHelper import (
     zenApiImpactRouterHelper,

--- a/examples/ImpactRouter_printTree.py
+++ b/examples/ImpactRouter_printTree.py
@@ -8,14 +8,14 @@ from zenApiImpactRouterHelper import (
 api = zenApiImpactRouterHelper()
 
 def printTree():
-    print "\nDisplaying tree of all services and organizers...\n"
-    print "GUID                                 UID"
-    print "---------------------------------    ---------------------"
+    print("\nDisplaying tree of all services and organizers...\n")
+    print("GUID                                 UID")
+    print("---------------------------------    ---------------------")
     tree = api.get_services_tree()
     _printTreeRecursive(tree)
 
 def _printTreeRecursive(tree):
-    print tree['uuid'], tree['path']
+    print(tree['uuid'], tree['path'])
     for child in tree['children']:
        _printTreeRecursive(child)
 

--- a/examples/ImpactRouter_setPolicies.py
+++ b/examples/ImpactRouter_setPolicies.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 from zenApiImpactRouterHelper import (
     zenApiImpactRouterHelper,

--- a/examples/JobsRouter_getJobs.py
+++ b/examples/JobsRouter_getJobs.py
@@ -30,8 +30,8 @@ def getJobs():
 
 def jobReport():
     jobs = getJobs()
-    print 'Scheduled, Status, Description, Started, UUID, '\
-          'Finished, User, Type'
+    print('Scheduled, Status, Description, Started, UUID, '\
+          'Finished, User, Type')
     for job in jobs['jobs']:
         scheduled = job['scheduled']
         status = job['status']
@@ -41,14 +41,14 @@ def jobReport():
         finished = job['finished']
         user = job['user']
         jobtype = job['type']
-        print '%s, %s, %s, %s, %s, %s, %s, %s' % (scheduled,
+        print('%s, %s, %s, %s, %s, %s, %s, %s' % (scheduled,
                                                   status,
                                                   description,
                                                   started,
                                                   uuid,
                                                   finished,
                                                   user,
-                                                  jobtype)
+                                                  jobtype))
 
 
 if __name__ == '__main__':

--- a/examples/JobsRouter_getJobs.py
+++ b/examples/JobsRouter_getJobs.py
@@ -5,6 +5,7 @@
 # the Zenoss JSON API and the ZenAPIConnector class #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/JobsRouter_getLongRunningJobs.py
+++ b/examples/JobsRouter_getLongRunningJobs.py
@@ -5,6 +5,7 @@
 # the Zenoss JSON API and the ZenAPIConnector class #
 # written by Adam McCurdy @ Zenoss                  #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/JobsRouter_getLongRunningJobs.py
+++ b/examples/JobsRouter_getLongRunningJobs.py
@@ -63,10 +63,10 @@ def jobReport():
     jobs = getJobs()
     l_jobs = longRunning(jobs)
     if not l_jobs:
-        print 'No long running jobs found.'
+        print('No long running jobs found.')
     else:
-        print 'ScheduledTime, Status, Description, Started, UUID, '\
-            'User, Type'
+        print('ScheduledTime, Status, Description, Started, UUID, '\
+            'User, Type')
         for job in l_jobs:
                 scheduled = r_time(job['scheduled'])
                 status = job['status']
@@ -75,13 +75,13 @@ def jobReport():
                 uuid = job['uuid']
                 user = job['user']
                 jobtype = job['type']
-                print '%s, %s, %s, %s, %s, %s, %s' % (scheduled,
+                print('%s, %s, %s, %s, %s, %s, %s' % (scheduled,
                                                         status,
                                                         description,
                                                         started,
                                                         uuid,
                                                         user,
-                                                        jobtype)
+                                                        jobtype))
 
 
 if __name__ == '__main__':

--- a/examples/ProcessRouter_addProcessDefFromFile.py
+++ b/examples/ProcessRouter_addProcessDefFromFile.py
@@ -7,6 +7,7 @@
 # line contains a new process.  This was done so    #
 # the script could be re-used without modifying it  #
 #####################################################
+from __future__ import print_function
 
 # stdlib Imports
 import json

--- a/examples/PropertiesRouter_DeviceRouter_RemoveEngnieID_ReModel.py
+++ b/examples/PropertiesRouter_DeviceRouter_RemoveEngnieID_ReModel.py
@@ -16,7 +16,7 @@ response = ZenDeviceUidFinder(name=device_id)
 if response.getCount() == 1:
     device_uid = response.getFirstUid()
 else:
-    print 'Found %s devices.' % (response.getCount())
+    print('Found %s devices.' % (response.getCount()))
     sys.exit(1)
 
 pr = zenApiLib.zenConnector(routerName='PropertiesRouter')
@@ -26,9 +26,9 @@ delete_response = pr.callMethod('deleteZenProperty',
                                 uid=device_uid)
 
 if delete_response['result']['success'] == True:
-    print 'Deleted EngineID on %s' % (device_uid)
+    print('Deleted EngineID on %s' % (device_uid))
 else:
-    print 'Unable to delete EngineID on %s' % (device_uid)
+    print('Unable to delete EngineID on %s' % (device_uid))
     sys.exit(1)
 
 dr = zenApiLib.zenConnector(routerName='DeviceRouter')
@@ -36,4 +36,4 @@ dr = zenApiLib.zenConnector(routerName='DeviceRouter')
 remodel_response = dr.callMethod('remodel', deviceUid=device_uid)
 
 if remodel_response['result']['success'] == True:
-    print 'Model job submitted.'
+    print('Model job submitted.')

--- a/examples/PropertiesRouter_DeviceRouter_RemoveEngnieID_ReModel.py
+++ b/examples/PropertiesRouter_DeviceRouter_RemoveEngnieID_ReModel.py
@@ -5,6 +5,7 @@
 # and re-model a device to handle a specific customer          #
 # use-case.                                                    #
 ################################################################
+from __future__ import print_function
 import sys
 import zenApiLib
 from zenApiDeviceRouterHelper import ZenDeviceUidFinder

--- a/examples/PropertiesRouter_getZenProperties.py
+++ b/examples/PropertiesRouter_getZenProperties.py
@@ -5,6 +5,7 @@
 # using the Zenoss JSON API and the ZenAPIConnector #
 # class written by Adam McCurdy @ Zenoss            #
 #####################################################
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/PropertiesRouter_getZenProperties.py
+++ b/examples/PropertiesRouter_getZenProperties.py
@@ -32,14 +32,14 @@ def printProperties(response):
         isLocal = prop['islocal']
         value = prop['value']
         description = prop['description']
-        print '%s,,%s,,%s,,%s,,%s,,%s' % (id,
+        print('%s,,%s,,%s,,%s,,%s,,%s' % (id,
                                           category,
                                           label,
                                           isLocal,
                                           value,
-                                          description)
+                                          description))
 
 if __name__ == '__main__':
     response = getProperties()
-    print 'ID,,Category,,Label,,IsLocal?,,Value,,Description'
+    print('ID,,Category,,Label,,IsLocal?,,Value,,Description')
     printProperties(response)

--- a/examples/ServiceRouter_ChangeWinServerFromFile.py
+++ b/examples/ServiceRouter_ChangeWinServerFromFile.py
@@ -7,6 +7,7 @@
 # line contains a new process.  This was done so    #
 # the script could be re-used without modifying it  #
 #####################################################
+from __future__ import print_function
 
 # stdlib Imports
 import json

--- a/examples/TemplateRouter_ThresholdEnableDisable.py
+++ b/examples/TemplateRouter_ThresholdEnableDisable.py
@@ -1,5 +1,6 @@
 #!/bin/env python
 # Enable or disable a threshold
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/TemplateRouter_ThresholdReport.py
+++ b/examples/TemplateRouter_ThresholdReport.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 import zenApiLib
 import argparse
 import sys

--- a/examples/TemplateRouter_bulkAPITemplateUpdate.py
+++ b/examples/TemplateRouter_bulkAPITemplateUpdate.py
@@ -59,11 +59,11 @@ def bulkUpdateTemplates():
        try: 
            dm_components = directoryMonitorComponents['result']['data'][0]['uid']
        except IndexError: 
-           print "Skipping because no directory monitor component"
+           print("Skipping because no directory monitor component")
            continue
        datasources = templateRouter.callMethod('getDataSources', uid=(dm_components + "/" + "DirectoryMonitor"))
        change_datasource = datasources['result']['data'][0]['uid']
        templateRouter.callMethod('setInfo', uid=(change_datasource), script=new_script)
-       print "Changing %s on %s" % (change_datasource, dev) 
+       print("Changing %s on %s" % (change_datasource, dev)) 
 if __name__ == '__main__':
     bulkUpdateTemplates()

--- a/examples/TemplateRouter_bulkAPITemplateUpdate.py
+++ b/examples/TemplateRouter_bulkAPITemplateUpdate.py
@@ -6,6 +6,7 @@
 # In this example we throw in a new script into the
 # datasource.  This is a pretty quick and dirty method #
 #####################################################
+from __future__ import print_function
 
 # stdlib Imports
 import json

--- a/examples/TriggersRouter_export.py
+++ b/examples/TriggersRouter_export.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 # stdlib Imports
 import json

--- a/examples/TriggersRouter_export.py
+++ b/examples/TriggersRouter_export.py
@@ -15,10 +15,10 @@ def TriggerRouter(sMethod, dData={}):
     zenAPI.setRouter('TriggersRouter')
     respData = zenAPI.callMethod(sMethod, **dData)
     if not respData['result']['success']:
-        print "ERROR: TriggerRouter %s method call non-successful" % sMethod
-        print respData
-        print "Data submitted was:"
-        print response.request.body
+        print("ERROR: TriggerRouter %s method call non-successful" % sMethod)
+        print(respData)
+        print("Data submitted was:")
+        print(response.request.body)
         exit(1)
     return respData['result']['data']
     
@@ -28,11 +28,11 @@ def write2File(sType, lData):
     if not os.path.exists(exportPath):
         os.makedirs(exportPath)
     for dEntry in lData:
-        print "INFO: writing %s/%s.%s.json" % (
+        print("INFO: writing %s/%s.%s.json" % (
             exportPath,
             dEntry['name'],
             sType
-        )
+        ))
         try:
             trigFile = open("%s/%s.%s.json" % (
                 exportPath,
@@ -43,29 +43,29 @@ def write2File(sType, lData):
             trigFile.write(json.dumps(dEntry))
             trigFile.close()
         except Exception, e:
-            print "ERROR: %s" % (e)
+            print("ERROR: %s" % (e))
             exit(1)
 
 if __name__ == "__main__":
-    print "Script started, exporting from %s" % zenInstance
+    print("Script started, exporting from %s" % zenInstance)
     lTriggers = TriggerRouter('getTriggers')
-    print "INFO: got event triggers, total of %s" % (
+    print("INFO: got event triggers, total of %s" % (
         str(len(lTriggers))
-    )
+    ))
     write2File('trigger', lTriggers)
     #
     lNotifications = TriggerRouter('getNotifications')
-    print "INFO: got event notifications, total of %s" % (
+    print("INFO: got event notifications, total of %s" % (
         str(len(lNotifications))
-    )
+    ))
     write2File('notification', lNotifications)
     #
     lNotifWindows = []
     for dNotif in lNotifications:
         lWindows = TriggerRouter('getWindows', dData={'uid': dNotif['uid']})
         lNotifWindows = lNotifWindows + lWindows
-    print "INFO: got event notifications windows, total of %s" % (
+    print("INFO: got event notifications windows, total of %s" % (
         str(len(lNotifWindows))
-    )
+    ))
     write2File('window', lNotifWindows)
-    print "Script completed"
+    print("Script completed")

--- a/examples/TriggersRouter_import.py
+++ b/examples/TriggersRouter_import.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 # stdlib Imports
 import json

--- a/examples/TriggersRouter_import.py
+++ b/examples/TriggersRouter_import.py
@@ -26,10 +26,10 @@ def TriggerRouter(sMethod, dData={}):
     zenAPI.setRouter('TriggersRouter')
     respData = zenAPI.callMethod(sMethod, **dData)
     if not respData['result']['success']:
-        print "ERROR: TriggerRouter %s method call non-successful" % sMethod
-        print respData
-        print "Data submitted was:"
-        print response.request.body
+        print("ERROR: TriggerRouter %s method call non-successful" % sMethod)
+        print(respData)
+        print("Data submitted was:")
+        print(response.request.body)
         exit(1)
     return respData['result']['data']
 
@@ -61,7 +61,7 @@ def getNameIdx(type):
         # getting an index for windows is more invovled
         return _getWindowNameIdx()
     elif not (type in dTypeId.keys()):
-        print "ERROR: Caching %s Name-ID index: no such type" % type
+        print("ERROR: Caching %s Name-ID index: no such type" % type)
         return {}
     log.debug("Caching Index for %ss" % type)
     lResult = TriggerRouter(dTypeId[type]['apiTriggerRouter'])
@@ -95,7 +95,7 @@ def _getWindowNameIdx():
 
 def getConfigOrCreate(type, data):
     if not (type in "trigger, notification, window"):
-        print "ERROR: %s creation: no such type" % type
+        print("ERROR: %s creation: no such type" % type)
         return {}
     if ((
             type == 'trigger' and
@@ -170,9 +170,9 @@ def _getConfig(type, data, warn=False):
                 dConfig = dNotif
                 break
         if dConfig == {}:
-            print "ERROR: Did not find notification config for %s" % (
+            print("ERROR: Did not find notification config for %s" % (
                 data['name']
-            )
+            ))
     elif type == 'window':
         # Windows API calls require Notification uid
         # sNotifUid=_getWindowNotifUid(data['uid'])
@@ -314,7 +314,7 @@ if __name__ == "__main__":
     argv.pop(0)
     for sFileName in argv:
         if not os.path.isfile(sFileName):
-            print "ERROR: %s does not exist, ignoring" % sFileName
+            print("ERROR: %s does not exist, ignoring" % sFileName)
             continue
         log.info("Reading file %s" % sFileName)
         oFile = open(sFileName, 'r')
@@ -356,7 +356,7 @@ if __name__ == "__main__":
             if dWinsIndex == {}:
                 dWinsIndex = getNameIdx(type)
         else:
-            print "ERROR: unknown type"
+            print("ERROR: unknown type")
             exit(1)
         # Create Notification
         dZenConfig = getConfigOrCreate(type, dImportData)

--- a/examples/ZenPackRouter_getZenPackMetaData.py
+++ b/examples/ZenPackRouter_getZenPackMetaData.py
@@ -8,4 +8,4 @@ if __name__ == '__main__':
     apiResp = zenApi.callMethod('getZenPackMetaData')
     for zpKey in sorted(apiResp['result']['data']):
         zpMeta = apiResp['result']['data'][zpKey]
-        print zpMeta['name'], zpMeta['version'] 
+        print(zpMeta['name'], zpMeta['version']) 

--- a/examples/ZenPackRouter_getZenPackMetaData.py
+++ b/examples/ZenPackRouter_getZenPackMetaData.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import zenApiLib
 

--- a/examples/flask_dashboard.py
+++ b/examples/flask_dashboard.py
@@ -2,6 +2,7 @@
 # This is an example of using Flask to create an external,     #
 # api-driven dashboard using zenApiLib.                        #
 ################################################################
+from __future__ import print_function
 
 from flask import Flask
 import zenApiLib

--- a/zenApiCli.py
+++ b/zenApiCli.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
                                                ):
         if not nested_get(pagedResult, ['result', 'success']) != "False":
             pprint(pagedResult)
-            print " "
+            print(" ")
             log.error("API success FALSE")
             sys.exit(1)
         for rFieldName in rFields:
@@ -162,4 +162,4 @@ if __name__ == '__main__':
     for k in rFields:
         if k == 'all':
             continue
-        print "{}:{}".format(k, rTotalResults[k])
+        print("{}:{}".format(k, rTotalResults[k]))

--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -86,7 +86,7 @@ class zenConnector():
         if 'cz' in configuration:
             if not 'apikey' in configuration:
                 raise Exception('Configuration file missing "apikey" key')
-            configuration['url'] = configuration['url'] + '/' + configuration['cz']
+            configuration['url'] = '{}/{}'.format(configuration['url'], configuration['cz'])
         elif 'username' in configuration:
             if not 'password' in configuration:
                 self.log.error('Configuration file missing "password" key')
@@ -286,10 +286,9 @@ class zenConnector():
         # To query if specified router exists, first need to query all available routers.
         # Temporarily setting to 'IntrospectionRouter' in order to do so.
         self._routerName = 'IntrospectionRouter'
+        self._url = self.config['url'] + self._getEndpoint('IntrospectionRouter')
         if self.config['disable_saml'] == True:
-            self._url = self.config['url'] + self._getEndpoint('IntrospectionRouter') + '?saml=0'
-        else:
-            self._url = self.config['url'] + self._getEndpoint('IntrospectionRouter')
+            self._url +='?saml=0'
         # Query all available routers
         if self._routersInfo == {}:
             apiResp = self.callMethod('getAllRouters')
@@ -321,10 +320,9 @@ class zenConnector():
             self._routersInfo[routerName]['methods'] = dict(apiResp['result']['data'])
         # Set router
         self._routerName = routerName
+        self._url = self.config['url'] + self._getEndpoint(routerName)
         if self.config['disable_saml'] == True:
-            self._url = self.config['url'] + self._getEndpoint(routerName) + '?saml=0'
-        else: 
-            self._url = self.config['url'] + self._getEndpoint(routerName)
+            self._url +='?saml=0'
        
 
     def _getEndpoint(self, routerName):

--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python
 import os
-import requests
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from requests.packages.urllib3.util.retry import Retry
-from httplib import HTTPConnection
-from requests.adapters import HTTPAdapter
 import json
-import ConfigParser
-from HTMLParser import HTMLParser
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+# Try to import from python 2 locations, fallback to python3.
+try:
+    from httplib import HTTPConnection
+    from HTMLParser import HTMLParser
+    import ConfigParser
+except:
+    from http.client import HTTPConnection
+    from html.parser import HTMLParser
+    import configparser as ConfigParser
+
 
 if not ('logging' in dir()):
     import logging
@@ -344,7 +352,7 @@ class ZenAPIConnector(zenConnector):
         self._tid = 0
         self.log = logging.getLogger('zenApiLib.ZenAPIConnector')
         self.log.warn('This is a backwards compatibility adapter.')
-        print "WARN: This is a backwards compatibility adapter."
+        print("WARN: This is a backwards compatibility adapter.")
         self.config = self._getConfigDetails('default', '')
         self.requestSession = self.getRequestSession()
         self.setRouter(router)
@@ -378,6 +386,6 @@ class TitleParser(HTMLParser):
 
 
 if __name__ == '__main__':
-    print "For help reference the README.md file"
-    print "If you are trying to make a command line call to the API, all command line invocations functions have been moved to zenApiCli.py"
+    print("For help reference the README.md file")
+    print("If you are trying to make a command line call to the API, all command line invocations functions have been moved to zenApiCli.py")
     

--- a/zenApiLib.py
+++ b/zenApiLib.py
@@ -11,7 +11,7 @@ try:
     from httplib import HTTPConnection
     from HTMLParser import HTMLParser
     import ConfigParser
-except:
+except ImportError:
     from http.client import HTTPConnection
     from html.parser import HTMLParser
     import configparser as ConfigParser


### PR DESCRIPTION
Small changes to get things to play nice with py3.

I don't have time to check each example script, but DeviceDumpLoadRouter_exportDevices.py and APIGetDocumentation.py worked on python2 and 3.

I don't see any other imports from standard lib modules that got moved in python3, but more eyes would always be good.